### PR TITLE
Text/typo fixes

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -34,7 +34,7 @@ Interventions boosting physical activity represent a 'magic bullet', tackling ob
 Active travel is a rapidly growing topic of multi-disciplinary research but has received limited attention from data science perspectives, with a recent paper on modelling cycle network growth [@orozco_datadriven_2020] providing a notable exception.
 The work will be grounded in geographic data science, building on previous studies assessing open datasets for transport applications [@ferster_using_2020; @haklay_how_2010a].
 
-In the post-pandemic world, active modes will be even more important due to reduced public transport capacities, as highlighted by the Department for Transport's £250m Active Travel Fund (ATF) and £2b allocated to walking and cycling over the next 5 years in the UK alone.
+In the post-pandemic world, active modes will be even more important due to reduced public transport capacities, as highlighted by the Department for Transport's £250m Active Travel Fund (ATF) and £2bn allocated to walking and cycling over the next 5 years in the UK alone.
 
 New policies and investment programs such as the ATF have led to increased demand for local evidence to inform interventions ranging from new cycleways to improved pavement quality.
 This project will the potential of open access transport sources such as OpenStreetMap (OSM) and Ordnance Survey Open Roads (OSOR) datasets, and associated tools, for transport planning to meet active travel objectives.
@@ -63,7 +63,7 @@ There are already good tools open tools for working with transport infrastructur
 These, and packages written in other languages such as Julia and Python, are largely academic-led and technical projects with little uptake among practitioners. 
 This project will explore the landscape of open transport infrastructure, describe and critique how active travel infrastructure is represented, and document how practitioners can better use open data for evidence-based, transparent and participatory active travel interventions.
 
-Local authority planners and other stakeholders have more data than ever before on transport systems to support their work, especially in relation to travel *behaviour* thanks to datasets from traffic counts, travel surveys and open access tools such as the Propensity to Cycle Tool 
+Local authority planners and other stakeholders have more data than ever before on transport systems to support their work, especially in relation to travel *behaviour* thanks to datasets from traffic counts, travel surveys and open access tools such as the Propensity to Cycle Tool.
 
 However, there is less accessible data on travel *infrastructure*, especially in relation to walking and cycling.
 Good practice on designing for active travel is well known [@departmentfortransport_manual_2007; @parkin_designing_2018] and increasingly recommended/enforced.
@@ -416,7 +416,7 @@ There is lots more we can do with this data and other open transport datasets, a
 - To get a deeper understanding of using geographic research transport research, Chapter 12 of the book Geocomputation with R is a great place to start: https://geocompr.robinlovelace.net/transport.html
 - For more on A/B Street scenarios, see here: https://a-b-street.github.io/docs/dev/formats/scenarios.html
 
-For any questions, feel free to ask in a GitHub issue track assocated with any of the repositories mentioned in this guide.
+For any questions, feel free to ask in a GitHub issue track associated with any of the repositories mentioned in this guide.
 
 
 # References

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Haklay 2010).
 
 In the post-pandemic world, active modes will be even more important due
 to reduced public transport capacities, as highlighted by the Department
-for Transport’s £250m Active Travel Fund (ATF) and £2b allocated to
+for Transport’s £250m Active Travel Fund (ATF) and £2bn allocated to
 walking and cycling over the next 5 years in the UK alone.
 
 New policies and investment programs such as the ATF have led to
@@ -93,7 +93,7 @@ Local authority planners and other stakeholders have more data than ever
 before on transport systems to support their work, especially in
 relation to travel *behaviour* thanks to datasets from traffic counts,
 travel surveys and open access tools such as the Propensity to Cycle
-Tool
+Tool.
 
 However, there is less accessible data on travel *infrastructure*,
 especially in relation to walking and cycling. Good practice on
@@ -447,7 +447,7 @@ the most important uses for sustainable transport planning.
 -   For more on A/B Street scenarios, see here:
     <https://a-b-street.github.io/docs/dev/formats/scenarios.html>
 
-For any questions, feel free to ask in a GitHub issue track assocated
+For any questions, feel free to ask in a GitHub issue track associated
 with any of the repositories mentioned in this guide.
 
 # References
@@ -515,8 +515,8 @@ Lovelace, Robin, Joseph Talbot, Malcolm Morgan, and Martin Lucas-Smith.
 
 <div id="ref-lucas-smith_mapping_2021" class="csl-entry">
 
-Lucas-Smith, Martin. 2021. “Mapping Modal Filters and LTNs.”
-CycleStreets. July 25, 2021.
+Lucas-Smith, Martin and Nuttall, Simon. 2021. “Mapping Modal Filters and LTNs.”
+CycleStreets Ltd. July 25, 2021.
 <https://www.cyclestreets.org/news/2021/07/25/mapping-ltns/>.
 
 </div>

--- a/references.bib
+++ b/references.bib
@@ -138,13 +138,13 @@
 
 @online{lucas-smith_mapping_2021,
   title = {Mapping Modal Filters and {{LTNs}}},
-  author = {Lucas-Smith, Martin},
+  author = {Lucas-Smith, Martin and Nuttall, Simon},
   date = {2021-07-25T21:29:29+00:00},
   url = {https://www.cyclestreets.org/news/2021/07/25/mapping-ltns/},
   urldate = {2021-09-23},
   abstract = {Modal filters – measures such as bollards, gates, cycle contraflows, etc., are important ways to prevent motor traffic passing through residential areas. They have been much in the news recently, but are in fact very common, and have been in existence since at least the 1980s. However, there is no national mapping data on where [...]},
   langid = {british},
-  organization = {{CycleStreets}},
+  organization = {{CycleStreets Ltd}},
   file = {/home/robin/Zotero/storage/8CHMCW53/mapping-ltns.html}
 }
 

--- a/vignettes/openinfra.Rmd
+++ b/vignettes/openinfra.Rmd
@@ -24,7 +24,7 @@ OpenStreetMap (OSM) has contributed to the shift in perception of who can map an
 - empowering citizens to represent their local environments;
 - encouraging the participation of citizens in policy making;
 
-The importance of local knowledge is also highlighted in the [LTN 1/20 guide](https://www.gov.uk/government/publications/cycle-infrastructure-design-ltn-120) in the context of ensuring successful implementation of a scheme. Hence, OSM can be a tool to foster a bottom-up approach in active travel planning through the inclusion of citizens in the data generation process. This, consequently, can be used to vocalise their needs leading to an increased likelihood of achieving higher uptake levels. 
+The importance of local knowledge is also highlighted in the [LTN 1/20 guidance](https://www.gov.uk/government/publications/cycle-infrastructure-design-ltn-120) in the context of ensuring successful implementation of a scheme. Hence, OSM can be a tool to foster a bottom-up approach in active travel planning through the inclusion of citizens in the data generation process. This, consequently, can be used to vocalise their needs leading to an increased likelihood of achieving higher uptake levels.
 
 # What is the structure of OpenStreetMap data?
 
@@ -84,7 +84,7 @@ Tags are not *exactly* data structures but they play a vital role in OSM because
 
 A tag is a concept that refers to a key="value" pair. A key describes a topic while value is a specification of a yopic. For instance, highway="cycleway" indicates that it is a highway (i.e., a line) and, specifically, a cycleway. It is important to note that a value is not always unique in a sense that it can also be a key. For example, there is a "cycleway" tag, which is used to further detail cycling infrastructure. Hence, it is important to pay attention to the syntax of a tag to understand its meaning and use in a given context.
 
-Moreover, each OSM element can have multiple tags and the use of tags is not limited to certain data elements. Thus, theoretically, a point could be `highway="footway"`. The lack of restrictions is inherent in OSM. It relies on the mappers to make decisions that are the most sensible in their local contexts. This does not mean, however, that there are no conventions about the most appropriate way of tagging something. A simple example would be a depreciation of a `sidewalk="none"` tag which should be changed to `sidewalk="no"`. A more intricate example is a question concerning the mapping of sidewalks as currently there are two proposed schemes: one considering a sidewalk as a tag on a highway and another proposing to map footways as separate ways. 
+Moreover, each OSM element can have multiple tags and the use of tags is not limited to certain data elements. Thus, theoretically, a point could be `highway="footway"`. The lack of restrictions is inherent in OSM. It relies on the mappers to make decisions that are the most sensible in their local contexts. This does not mean, however, that there are no conventions about the most appropriate way of tagging something. A simple example would be a deprecation of a `sidewalk="none"` tag which should be changed to `sidewalk="no"`. A more intricate example is a question concerning the mapping of sidewalks as currently there are two proposed schemes: one considering a sidewalk as a tag on a highway and another proposing to map footways as separate ways. 
 
 Figure 1 shows 8 different tags that are important in transport research and their presence/absence in central Leeds.
 
@@ -163,13 +163,13 @@ highway_table = data.frame("Highway" = c("cycleway",
                                        "trunk_link",
                                        "unclassified"
                                        ),
-                           Meaning = c("Pats for cycling",
+                           Meaning = c("Paths for cycling",
                                        "Footpaths",
                                        "Streets where pedestrians have priority over cars",
                                        "Motorways or freeways",
                                        "Motorways or freeways",
                                        "Unspecified paths",
-                                       "Pedestrian only streets",
+                                       "Pedestrianised streets",
                                        "Primary roads",
                                        "Primary roads",
                                        "Roads in residential areas",
@@ -239,7 +239,7 @@ OSM has also been joined to other datasets, such as Strava or GPS and travel dia
 Finally, OSM data has been used in a number of open-access, and for social good in general, projects: 
 
 - [A/B Street](https://a-b-street.github.io/docs/software/abstreet.html) is a simulation game that demonstrates how various small changes in road infrastructure affects its users. 
-- [Cyclestreets](https://www.cyclestreets.net/) is a UK-wide route planning system for cyclists.
+- [CycleStreets](https://www.cyclestreets.net/) is a UK-wide route planning system for cyclists.
 - [WheelMap](https://wheelmap.org/search) provides a map that shows wheelchair (in)accessible places.
 
 ## Why use OSM?


### PR DESCRIPTION
Various fixes:

- Typos
- CycleStreets corrected name
- LTNs article should be attributed to both Lucas-Smith and Nuttall
- highway=pedestrian is not exclusively pedestrian